### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -40,8 +40,8 @@ $(function(){
   });
 
   $(document).on("click", ".user-search-add", function(){
-    var user_id = $(this).attr('data-user-id');
-    var user_name = $(this).attr('data-user-name');
+    var user_id = $(this).data('user-id');
+    var user_name = $(this).data('user-name');
     var select_list = $(".chat-group-users");
     var html = `<div class='chat-group-user'>
                   <input name='group[user_ids][]' type='hidden' value='${user_id}'>

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,58 @@
+$(function(){
+  var search_list = $("#user-search-result");
+  function appendUser(user){
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${user.name}</p>
+                  <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+                </div>`
+    search_list.append(html);
+  }
+
+  function appendErrMsgToHTML(msg){
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${msg}</p>
+                </div>`
+    search_list.append(html);
+  }
+
+  $("#user-search-field").on("keyup", function(){
+    var input = $("#user-search-field").val();
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    .done(function(users) {
+      $("#user-search-result").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user){
+          appendUser(user);
+        });
+      }
+      else {
+        appendErrMsgToHTML("一致するユーザーが見つかりません");
+      }
+    })
+    .fail(function() {
+      alert('ユーザー検索に失敗しました');
+    })
+  });
+
+  $(document).on("click", ".user-search-add", function(){
+    var user_id = $(this).attr('data-user-id');
+    var user_name = $(this).attr('data-user-name');
+    var select_list = $(".chat-group-users");
+    var html = `<div class='chat-group-user'>
+                  <input name='group[user_ids][]' type='hidden' value='${user_id}'>
+                  <p class='chat-group-user__name'>${user_name}</p>
+                  <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</div>
+                </div>`
+    select_list.append(html);
+    $(this).parent().remove();
+  });
+
+  $(document).on("click", ".user-search-remove", function(){
+    $(this).parent().remove();
+  });
+});

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -18,6 +18,10 @@ class GroupsController < ApplicationController
     end
   end
 
+  def edit
+    
+  end
+
   def update
     if @group.update(group_params)
       redirect_to group_messages_path(@group), notice: 'グループを編集しました'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,12 @@
 class UsersController < ApplicationController
+  def index
+    @users = User.where('name LIKE(?)', "#{params[:keyword]}%")
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where('name LIKE(?)', "#{params[:keyword]}%")
+    @users = User.where('name LIKE(?) and id != ?', "#{params[:keyword]}%", current_user)
     respond_to do |format|
       format.html
       format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -13,11 +13,9 @@
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{for: "user-search-field"} チャットメンバーを追加
-      /= label :name, 'チャットメンバーを追加', class: 'chat-group-form__label', for: "user-search-field"
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
         %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}
-        /= text_field :name, "", id: 'user-search-field', class: 'chat-group-form__input', placeholder: "追加したいユーザー名を入力してください"
       #user-search-result
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -7,18 +7,31 @@
           %li= message
   .chat-group-form__field
     .chat-group-form__field--left
-      = f.label :name, class: 'chat-group-form__label'
+      = f.label :name, 'グループ名', class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+    .chat-group-form__field--left
+      %label.chat-group-form__label{for: "user-search-field"} チャットメンバーを追加
+      /= label :name, 'チャットメンバーを追加', class: 'chat-group-form__label', for: "user-search-field"
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}
+        /= text_field :name, "", id: 'user-search-field', class: 'chat-group-form__input', placeholder: "追加したいユーザー名を入力してください"
+      #user-search-result
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      .chat-group-users
+        - @group.users.each do |user|
+          .chat-group-user
+            %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+            %p.chat-group-user__name
+              = user.name
+            .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
+
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -13,8 +13,7 @@
             %li.header__left__members__member
               = user.name
       .header__right
-        .header__right__btn
-          Edit
+        = link_to 'Edit', edit_group_path(@group), class: 'header__right__btn'
     .messages
       = render @messages
     .form

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end


### PR DESCRIPTION
#what
チャットグループに追加するユーザの検索をインクリメンタルサーチによって行えるようにする。また、検索後に追加したいユーザが選択でき、保存ボタンが押された時にユーザをparamsに追加できるようにする。

#why
インクリメンタルサーチの実装により検索結果が即時に得られ、検索結果からメンバーの追加、削除がページの更新をしなくても非同期通信によって行われる。常に最新の状態が見れることでユーザにとってより使いやすさ、誤操作の防止などの観点でよくなる。
