### PR TITLE
チャット画面の自動更新機能を実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -20,25 +20,6 @@ $(function(){
     return html;
   };
 
-  function buildMessageHTML(message){
-    var messageContent = (message.content != null) ? `<p class="message__lower__content">${message.content}</p>` : "";
-    var messageImage = (message.image.url != null) ? `<img src="${message.image.url}" class="message__lower__image" >` : "";
-    var html = `<div class="message" data-message-id=${message.id}>
-                  <div class="message__upper">
-                    <div class="message__upper__user">
-                      ${message.user_name}
-                    </div>
-                    <div class="message__upper__date">
-                      ${message.created_at}
-                    </div>
-                  </div>
-                  <div class="message__lower">
-                    ${messageContent}
-                    ${messageImage}
-                  </div>
-                </div>`
-    return html;
-  };
 
   function reloadMessages(){
     last_message_id = $('.message:last').data('message-id');
@@ -51,7 +32,7 @@ $(function(){
     .done(function(messages) {
       var insertHTML = '';
       messages.forEach(function(message){
-        insertHTML = insertHTML + buildMessageHTML(message);
+        insertHTML = insertHTML + buildHTML(message);
       });
       $('.messages').append(insertHTML);
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,6 @@
 $(function(){
   function buildHTML(message){
+    var messageContent = (message.content != null) ? `<p class="message__lower__content">${message.content}</p>` : "";
     var messageImage = (message.image != null) ? `<img src="${message.image}" class="message__lower__image" >` : "";
     var html =
       `<div class="message" data-message-id=${message.id}>
@@ -12,64 +13,30 @@ $(function(){
           </div>
         </div>
         <div class="message__lower">
-          <p class="message__lower__content">
-            ${message.content}
-          </p>
+          ${messageContent}
+          ${messageImage}
         </div>
-        ${messageImage}
       </div>`
     return html;
   };
 
   function buildMessageHTML(message){
-    if (message.content && message.image.url) {
-      var html = `<div class="message" data-message-id=${message.id}>
-                    <div class="message__upper">
-                      <div class="message__upper__user">
-                        ${message.user_name}
-                      </div>
-                      <div class="message__upper__date">
-                        ${message.created_at}
-                      </div>
+    var messageContent = (message.content != null) ? `<p class="message__lower__content">${message.content}</p>` : "";
+    var messageImage = (message.image.url != null) ? `<img src="${message.image.url}" class="message__lower__image" >` : "";
+    var html = `<div class="message" data-message-id=${message.id}>
+                  <div class="message__upper">
+                    <div class="message__upper__user">
+                      ${message.user_name}
                     </div>
-                    <div class="message__lower">
-                      <p class="message__lower__content">
-                        ${message.content}
-                      </p>
-                      <img src="${message.image.url}" class="message__lower__image">
+                    <div class="message__upper__date">
+                      ${message.created_at}
                     </div>
-                  </div>`
-    } else if (message.content) {
-      var html = `<div class="message" data-message-id=${message.id}>
-                    <div class="message__upper">
-                      <div class="message__upper__user">
-                        ${message.user_name}
-                      </div>
-                      <div class="message__upper__date">
-                        ${message.created_at}
-                      </div>
-                    </div>
-                    <div class="message__lower">
-                      <p class="message__lower__content">
-                        ${message.content}
-                      </p>
-                    </div>
-                  </div>`
-    } else if (message.image.url) {
-      var html = `<div class="message" data-message-id=${message.id}>
-                    <div class="message__upper">
-                      <div class="message__upper__user">
-                        ${message.user_name}
-                      </div>
-                      <div class="message__upper__date">
-                        ${message.created_at}
-                      </div>
-                    </div>
-                    <div class="message__lower">
-                      <img src="${message.image.url}" class="message__lower__image">
-                    </div>
-                  </div>`
-    };
+                  </div>
+                  <div class="message__lower">
+                    ${messageContent}
+                    ${messageImage}
+                  </div>
+                </div>`
     return html;
   };
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -19,7 +19,80 @@ $(function(){
         ${messageImage}
       </div>`
     return html;
-  }
+  };
+
+  function buildMessageHTML(message){
+    if (message.content && message.image.url) {
+      var html = `<div class="message" data-message-id=${message.id}>
+                    <div class="message__upper">
+                      <div class="message__upper__user">
+                        ${message.user_name}
+                      </div>
+                      <div class="message__upper__date">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="message__lower">
+                      <p class="message__lower__content">
+                        ${message.content}
+                      </p>
+                      <img src="${message.image.url}" class="message__lower__image">
+                    </div>
+                  </div>`
+    } else if (message.content) {
+      var html = `<div class="message" data-message-id=${message.id}>
+                    <div class="message__upper">
+                      <div class="message__upper__user">
+                        ${message.user_name}
+                      </div>
+                      <div class="message__upper__date">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="message__lower">
+                      <p class="message__lower__content">
+                        ${message.content}
+                      </p>
+                    </div>
+                  </div>`
+    } else if (message.image.url) {
+      var html = `<div class="message" data-message-id=${message.id}>
+                    <div class="message__upper">
+                      <div class="message__upper__user">
+                        ${message.user_name}
+                      </div>
+                      <div class="message__upper__date">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="message__lower">
+                      <img src="${message.image.url}" class="message__lower__image">
+                    </div>
+                  </div>`
+    };
+    return html;
+  };
+
+  function reloadMessages(){
+    last_message_id = $('.message:last').data('message-id');
+    $.ajax({
+      url: 'api/messages',
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      var insertHTML = '';
+      messages.forEach(function(message){
+        insertHTML = insertHTML + buildMessageHTML(message);
+      });
+      $('.messages').append(insertHTML);
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+    })
+    .fail(function() {
+    });
+  };
+
   $('.js-form').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -43,4 +116,10 @@ $(function(){
     })
     return false;
   });
+
+  var controller = $('body').data('controller');
+  var action = $('body').data('action');
+  if (controller == "messages" && action == "index") {
+    setInterval(reloadMessages, 5000);
+  };
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_messge_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at.strftime("%Y/%m/%d/ %H:%M")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.content message.content
-  json.image message.image
-  json.created_at message.created_at.strftime("%Y/%m/%d/ %H:%M")
+  json.image message.image.url
+  json.date message.created_at.strftime("%Y/%m/%d/ %H:%M")
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,6 +6,6 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags
-  %body
+  %body{data: {controller: "#{controller_name}", action: "#{action_name}"}}
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: "#{message.id}"}}}
   .message__upper
     .message__upper__user
       = message.user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#what
チャット画面が数秒おきに自動で更新する機能を実装する。画面に表示されている最新のメッセージからデータベースに保存されているメッセージで画面に表示されていない分を取得して表示するという形で実装する。

#why
現状ではメッセージを送信した時には非同期通信で画面が更新されるが、他のグループメンバーがメッセージを送信した時には画面が更新されずリロードしないと最新のメッセージが表示されないためアプリケーションの動作、機能として不十分であるため。